### PR TITLE
Add Duration Converter in Python (Issue #142)

### DIFF
--- a/DurationConverter-Python-JuanManuel/main.py
+++ b/DurationConverter-Python-JuanManuel/main.py
@@ -1,0 +1,34 @@
+ def convert_duration(value, source_unit, target_unit):
+    units = {
+        "second": 1,
+        "minute": 60,
+        "hour": 3600,
+        "day": 86400
+    }
+
+    if value < 0:
+        raise ValueError("Value must be positive")
+
+    if source_unit not in units or target_unit not in units:
+        raise ValueError("Invalid time unit")
+
+    value_in_seconds = value * units[source_unit]
+    return value_in_seconds / units[target_unit]
+
+
+def main():
+    print("\n--- Duration Converter (Python) ---\n")
+    
+    value = float(input("Enter a value: "))
+    source = input("Source unit (second/minute/hour/day): ").lower()
+    target = input("Target unit (second/minute/hour/day): ").lower()
+
+    try:
+        result = convert_duration(value, source, target)
+        print(f"\n{value} {source} -> {target} = {result}\n")
+    except Exception as e:
+        print("\nError:", e)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a Duration Converter implemented in Python.

- Folder added: DurationConverter-Python-JuanManuel
- File: main.py
- Supports conversion between: second, minute, hour, and day
- Includes input validation (non-negative values)
- Provides an interactive CLI interface
- Includes example inputs/outputs

Examples:
- 3600 second -> hour = 1
- 2 hour -> minute = 120
- 3 day -> hour = 72

This PR resolves Issue #142.
