### PR TITLE
PR : 2️⃣ Base Converter (Good First Issue)

### DIFF
--- a/Simple Calculators/Language Python/CLI/BaseConverterCLI-Python-calebjubal/README.md
+++ b/Simple Calculators/Language Python/CLI/BaseConverterCLI-Python-calebjubal/README.md
@@ -1,0 +1,24 @@
+# BaseConverter-Python-calebjubal
+
+Simple integer base converter supporting: binary (bin), octal (oct), decimal (dec), hexadecimal (hex).
+
+Usage (interactive):
+
+Run the script:
+
+```powershell
+python .\BaseConverter-Python-calebjubal\main.py
+```
+
+Then at the prompt type commands like:
+
+- convert 1010 bin dec    -> 10
+- convert 15 dec hex      -> F
+- convert 77 oct bin      -> 111111
+- convert 1F hex dec      -> 31
+
+Type `help` for examples or `exit` to quit.
+
+Notes:
+- Only integer conversions are supported (no fractional parts).
+- Negative integers are supported (leading `-`).

--- a/Simple Calculators/Language Python/CLI/BaseConverterCLI-Python-calebjubal/main.py
+++ b/Simple Calculators/Language Python/CLI/BaseConverterCLI-Python-calebjubal/main.py
@@ -1,0 +1,156 @@
+base_string = """
+Base Converter (Python)
+
+Supports converting integers between bases: binary (bin), octal (oct), decimal (dec), hexadecimal (hex).
+
+Usage (interactive):
+ - Run the script and type commands like:
+     convert 1010 bin dec
+     convert 15 dec hex
+     convert 77 oct bin
+     convert 1F hex dec
+ - Or type `exit` / `quit` to leave.
+
+Only integer conversion is supported (no fractional parts). Negative integers are accepted (e.g., -1A hex dec -> -26).
+"""
+
+import re
+from typing import Tuple
+
+BASE_MAP = {
+    'bin': 2,
+    'oct': 8,
+    'dec': 10,
+    'hex': 16,
+}
+
+# Regex to validate characters (digits and A-F) for integer inputs (with optional leading '-')
+_VALID_RE = re.compile(r"^-?[0-9A-Fa-f]+$")
+
+
+def normalize_base_name(name: str) -> str:
+    """Normalize base name (case-insensitive) and validate it.
+
+    Raises ValueError if base is unknown.
+    """
+    key = name.strip().lower()
+    if key not in BASE_MAP:
+        raise ValueError(f"Unknown base '{name}'. Supported: {', '.join(BASE_MAP.keys())}")
+    return key
+
+
+def validate_number_for_base(number: str, base_name: str) -> bool:
+    """Return True if `number` is a valid integer representation in `base_name`.
+
+    Accepts optional leading '-' for negative numbers. Letters A-F (case-insensitive) are allowed for hex.
+    """
+    if not _VALID_RE.match(number):
+        return False
+
+    # Remove optional leading '-'
+    num = number.lstrip('-')
+    base = BASE_MAP[base_name]
+
+    # Validate each digit is within base.
+    for ch in num:
+        # digits
+        if ch.isdigit():
+            val = ord(ch) - ord('0')
+        else:
+            # hex letters
+            val = ord(ch.upper()) - ord('A') + 10
+        if val >= base:
+            return False
+    return True
+
+
+def int_from_str(number: str, base_name: str) -> int:
+    """Convert validated `number` string in `base_name` to Python int.
+
+    Raises ValueError if invalid.
+    """
+    base = BASE_MAP[base_name]
+    try:
+        return int(number, base)
+    except ValueError as e:
+        raise ValueError(f"Invalid number '{number}' for base {base_name}") from e
+
+
+def format_int_to_base(value: int, base_name: str) -> str:
+    """Format Python int `value` into target `base_name` string representation.
+
+    Output uses uppercase hex letters and no prefixes (no 0x/0b/0o).
+    """
+    negative = value < 0
+    v = abs(value)
+    if base_name == 'dec':
+        out = str(v)
+    elif base_name == 'bin':
+        out = format(v, 'b')
+    elif base_name == 'oct':
+        out = format(v, 'o')
+    elif base_name == 'hex':
+        out = format(v, 'X')
+    else:
+        raise ValueError(f"Unknown target base: {base_name}")
+
+    return '-' + out if negative else out
+
+
+def convert_number(number: str, src_base: str, dst_base: str) -> str:
+    """Validate and convert `number` from `src_base` to `dst_base`.
+
+    Returns the converted string (without prefixes).
+    Raises ValueError on invalid input.
+    """
+    src = normalize_base_name(src_base)
+    dst = normalize_base_name(dst_base)
+
+    if not validate_number_for_base(number, src):
+        raise ValueError(f"Number '{number}' is not valid in base '{src}'")
+
+    n = int_from_str(number, src)
+    return format_int_to_base(n, dst)
+
+
+def _print_help():
+    print("Supported bases: bin, oct, dec, hex")
+    print("Examples:")
+    print("  convert 1010 bin dec    -> 10")
+    print("  convert 15 dec hex      -> F")
+    print("  convert 77 oct bin      -> 111111")
+    print("  convert 1F hex dec      -> 31")
+
+
+def interactive():
+    print(base_string, "\n(type 'help' for examples, 'exit' to quit)")
+    while True:
+        try:
+            raw = input('> ').strip()
+        except (EOFError, KeyboardInterrupt):
+            print()  # newline
+            break
+        if not raw:
+            continue
+        if raw.lower() in ('exit', 'quit'):
+            break
+        if raw.lower() in ('help', '?'):
+            _print_help()
+            continue
+
+        parts = raw.split()
+        if parts[0].lower() == 'convert' and len(parts) == 4:
+            _, num, src, dst = parts
+            try:
+                res = convert_number(num, src, dst)
+            except ValueError as e:
+                print(f"Error: {e}")
+            else:
+                print(res)
+        else:
+            # Fallback interactive flow: ask sequential questions
+            print("Enter command as: convert <number> <src> <dst>")
+
+
+if __name__ == '__main__':
+    interactive()


### PR DESCRIPTION
# new: 2️⃣ Base Converter (Good First Issue) #122 

## 📝 Summary

This PR introduces a standalone Python script (`base_converter.py`) capable of converting integers between four common numeral systems: Binary (`bin`), Octal (`oct`), Decimal (`dec`), and Hexadecimal (`hex`).

The utility features a robust interactive command-line interface (CLI) with input validation, error handling, and support for negative numbers.

## Key Objectives

- Accept user input for a number and the source & target bases:
  - Bases: Binary (bin), Octal (oct), Decimal (dec), Hexadecimal (hex)
- Validate input (e.g., ensure the number is valid for the given source base)
- Convert the number from the source base to the target base
- Display the result clearly

## ⚙️ Implementation Details

The converter operates by parsing the input string into a Python integer using the source base, and then formatting that integer into the destination base string.

Key implementation features:

  * **Validation:** Uses Regex (`re`) to ensure input strings contain valid characters before attempting conversion.
  * **Normalization:** Handles case-insensitivity for both commands and hex digits (e.g., `convert 1a Hex DEC` works).
  * **Negative Support:** Correctly handles negative integers (e.g., `-101` binary).
  * **Modular Design:** Logic is split into reusable functions (`normalize_base_name`, `validate_number_for_base`, `convert_number`) separate from the UI loop.

## 🧪 Testing Strategy

Manual testing was performed using the interactive shell to verify edge cases and standard conversions.

**Test Cases Run:**

1.  **Standard Conversion:**
      * `bin` -\> `dec`: `1010` -\> `10` (Pass)
      * `hex` -\> `dec`: `1F` -\> `31` (Pass)
      * `dec` -\> `oct`: `15` -\> `17` (Pass)
2.  **Negative Numbers:**
      * `hex` -\> `dec`: `-1A` -\> `-26` (Pass)
3.  **Invalid Inputs (Error Handling):**
      * Wrong digits for base: `convert 2 bin dec` -\> Throws validation error (Pass)
      * Garbage input: `convert xyz dec hex` -\> Throws validation error (Pass)
4.  **Case Insensitivity:**
      * `convert ff HEX dec` -\> `255` (Pass)

## 📸 Usage Examples

To run the tool:

```bash
python base_converter.py
```

**Sample Session:**

```text
> convert 1010 bin dec
10

> convert 1F hex dec
31

> convert -77 oct dec
-63

> convert 2 bin dec
Error: Number '2' is not valid in base 'bin'
```

## ✅ Checklist

  - [x] The code runs without errors.
  - [x] Input validation is strictly enforced (no letters in decimal, no '8' in octal).
  - [x] Code follows PEP 8 style guidelines (type hinting included).
  - [x] Edge cases (negative numbers, uppercase/lowercase) are handled.